### PR TITLE
Aplicamos prácticas de seguridad en contenedor

### DIFF
--- a/7.1-alpine/Dockerfile
+++ b/7.1-alpine/Dockerfile
@@ -74,10 +74,18 @@ EXPOSE 80
 FROM web as rootless
 
 ARG USER=siu
+ENV USER=$USER
 ARG UID=222
 
 RUN adduser -h /usr/local/app -u $UID -G www-data -S $USER \
-    && chown -R siu.www-data \
+    && chown -R $USER.0 \
+        /var/log/apache2 \
+        /var/run/apache2 \
+        /etc/php7/conf.d \
+        /etc/apache2/conf.d \
+        /var/www/localhost/htdocs \
+    && chmod -R g=u \
+        /etc/passwd \
         /var/log/apache2 \
         /var/run/apache2 \
         /etc/php7/conf.d \

--- a/7.1-alpine/Dockerfile
+++ b/7.1-alpine/Dockerfile
@@ -84,11 +84,13 @@ RUN adduser -h /usr/local/app -u $UID -G www-data -S $USER \
         /etc/php7/conf.d \
         /etc/apache2/conf.d \
         /var/www/localhost/htdocs \
+        /siu-entrypoint.d \
     && chmod -R g=u \
         /etc/passwd \
         /var/log/apache2 \
         /var/run/apache2 \
         /etc/php7/conf.d \
         /etc/apache2/conf.d \
-        /var/www/localhost/htdocs
+        /var/www/localhost/htdocs \
+        /siu-entrypoint.d
 USER $USER

--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -58,10 +58,18 @@ EXPOSE 80
 FROM web as rootless
 
 ARG USER=siu
+ENV USER=$USER
 ARG UID=222
 
 RUN adduser -h /usr/local/app -u $UID -G www-data -S $USER \
-    && chown -R siu.www-data \
+    && chown -R $USER.0 \
+        /var/run/apache2 \
+        /var/log/apache2 \
+        /etc/php7/conf.d \
+        /etc/apache2/conf.d \
+        /var/www/localhost/htdocs \
+    && chmod -R g=u \
+        /etc/passwd \
         /var/run/apache2 \
         /var/log/apache2 \
         /etc/php7/conf.d \

--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -68,11 +68,13 @@ RUN adduser -h /usr/local/app -u $UID -G www-data -S $USER \
         /etc/php7/conf.d \
         /etc/apache2/conf.d \
         /var/www/localhost/htdocs \
+        /siu-entrypoint.d \
     && chmod -R g=u \
         /etc/passwd \
         /var/run/apache2 \
         /var/log/apache2 \
         /etc/php7/conf.d \
         /etc/apache2/conf.d \
-        /var/www/localhost/htdocs
+        /var/www/localhost/htdocs \
+        /siu-entrypoint.d
 USER $USER

--- a/common/entrypoint.sh
+++ b/common/entrypoint.sh
@@ -2,6 +2,12 @@
 
 set -eo pipefail
 
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "siu-toba:x:$(id -u):0:SIU toba:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
 for i in /siu-entrypoint.d/* ; do
   source $i
 done


### PR DESCRIPTION
En este commit permitimos correr con cualquier usuario no privilegiado
al contenedor. La mejora aplica a la versión rootless y considera que el
usuario que usa para correr pueda tener un UID random. De hecho propone
poder correr la imagen de la siguiente forma:

docker run -u $((RANDOM +1)) --rm -it siutoba/php:xxxx-rootless