### PR TITLE
Compatibilidad con PHP8

### DIFF
--- a/7.1-alpine/Dockerfile
+++ b/7.1-alpine/Dockerfile
@@ -46,6 +46,7 @@ RUN apk --no-cache add \
     libsodium \
     curl \
     && rm -rf /var/cache/apk/* \
+    && echo "date.timezone  = $TZ" > /etc/php7/conf.d/80-siu-timezone.ini \
     && echo extension=libsodium.so > /etc/php7/conf.d/00_sodium.ini
 
 COPY --from=sodium /usr/lib/php7/modules/libsodium.so /usr/lib/php7/modules/

--- a/7.3-alpine/Dockerfile
+++ b/7.3-alpine/Dockerfile
@@ -52,6 +52,7 @@ RUN apk --no-cache add \
     && echo "ServerTokens Prod" >> /etc/apache2/httpd.conf \
     && echo "ServerSignature Off" >> /etc/apache2/httpd.conf \
     && echo "TraceEnable off" >> /etc/apache2/httpd.conf \
+    && echo "date.timezone  = $TZ" > /etc/php7/conf.d/80-siu-timezone.ini \
     && cp /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Set environments variables in config file

--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -33,6 +33,7 @@ RUN apk --no-cache add \
     php7-xsl \
     libsodium \
     curl \
+    && echo "date.timezone  = $TZ" > /etc/php7/conf.d/80-siu-timezone.ini \
     && rm -rf /var/cache/apk/*
 
 FROM cli as web

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -33,6 +33,7 @@ RUN apk --no-cache add \
     php8-pecl-memcached \    
     libsodium \
     curl \
+    && echo "date.timezone  = $TZ" > /etc/php8/conf.d/80-siu-timezone.ini \
     && rm -rf /var/cache/apk/*
 
 FROM cli as web

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -7,7 +7,6 @@ RUN apk --no-cache add \
     bash \
     tzdata \
     php8 \
-    php8-cli \
     php8-ctype \
     php8-curl \
     php8-dom \
@@ -38,8 +37,7 @@ RUN apk --no-cache add \
     && rm -rf /var/cache/apk/*
 
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
-RUN ln -s php8 /usr/bin/php
-
+RUN ln -s /usr/bin/php8 /usr/bin/php
 
 FROM cli as web
 

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -7,6 +7,7 @@ RUN apk --no-cache add \
     bash \
     tzdata \
     php8 \
+    php8-cli \
     php8-ctype \
     php8-curl \
     php8-dom \
@@ -35,6 +36,10 @@ RUN apk --no-cache add \
     curl \
     && echo "date.timezone  = $TZ" > /etc/php8/conf.d/80-siu-timezone.ini \
     && rm -rf /var/cache/apk/*
+
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
+RUN ln -s php8 /usr/bin/php
+
 
 FROM cli as web
 

--- a/common/siu-entrypoint.d/php-timezone
+++ b/common/siu-entrypoint.d/php-timezone
@@ -1,1 +1,0 @@
-echo "date.timezone  = $TZ" > /etc/php7/conf.d/80-siu-timezone.ini


### PR DESCRIPTION
Se elimina el mecanismo de configuración del entrypoint para setear el
timezone a partir de un archivo ejecutado desde entrypoint.d. Se mueve
la lógica a los Dockerfile respectivos.

Por otro lado, se agrega el link simbólico de php8 a php (Alpine [decidió](https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308) no hacerlo, a futuro se espera que puedan convivir diferentes versiones de PHP).