### PR TITLE
Mantiene soporte Docker 19.x

### DIFF
--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -62,7 +62,7 @@ FROM web as rootless
 
 # https://github.com/docker-library/httpd/issues/118
 # para soportar Docker <= 19.x
-RUN apk add libcap
+RUN apk --no-cache add libcap
 RUN setcap "cap_net_bind_service=+ep" /usr/sbin/httpd
 
 ARG USER=siu

--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -60,6 +60,11 @@ EXPOSE 80
 
 FROM web as rootless
 
+# https://github.com/docker-library/httpd/issues/118
+# para soportar Docker <= 19.x
+RUN apk add libcap
+RUN setcap "cap_net_bind_service=+ep" /usr/sbin/httpd
+
 ARG USER=siu
 ENV USER=$USER
 ARG UID=222

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -62,7 +62,7 @@ FROM web as rootless
 
 # https://github.com/docker-library/httpd/issues/118
 # para soportar Docker <= 19.x
-RUN apk add libcap
+RUN apk --no-cache add libcap
 RUN setcap "cap_net_bind_service=+ep" /usr/sbin/httpd
 
 ARG USER=siu

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -60,6 +60,11 @@ EXPOSE 80
 
 FROM web as rootless
 
+# https://github.com/docker-library/httpd/issues/118
+# para soportar Docker <= 19.x
+RUN apk add libcap
+RUN setcap "cap_net_bind_service=+ep" /usr/sbin/httpd
+
 ARG USER=siu
 ENV USER=$USER
 ARG UID=222

--- a/8.1-alpine/Dockerfile
+++ b/8.1-alpine/Dockerfile
@@ -63,6 +63,11 @@ EXPOSE 80
 
 FROM web as rootless
 
+# https://github.com/docker-library/httpd/issues/118
+# para soportar Docker <= 19.x
+RUN apk add libcap
+RUN setcap "cap_net_bind_service=+ep" /usr/sbin/httpd
+
 ARG USER=siu
 ENV USER=$USER
 ARG UID=222

--- a/8.1-alpine/Dockerfile
+++ b/8.1-alpine/Dockerfile
@@ -65,7 +65,7 @@ FROM web as rootless
 
 # https://github.com/docker-library/httpd/issues/118
 # para soportar Docker <= 19.x
-RUN apk add libcap
+RUN apk --no-cache add libcap
 RUN setcap "cap_net_bind_service=+ep" /usr/sbin/httpd
 
 ARG USER=siu

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ contenedores basadas en php en diferentes versiones del lenguaje:
 * [x] 7.3 (deprecated)
 * [x] 7.4
 * [x] 8.0
-* [ ] 8.1
+* [x] 8.1
 
 En cada versión, se proveen versiones para:
 


### PR DESCRIPTION
Al parecer, en versiones previas a 20.x de Docker engine, no se soporta la ejecución non-root de los contenedores.

- https://stackoverflow.com/questions/64593942/docker-13permission-denied-ah00072-make-sock-could-not-bind-to-address-0-0
- https://github.com/docker-library/httpd/issues/118

Esta es una solución similar a lo planteado acá
- https://github.com/hashicorp/docker-consul/pull/37/files