### PR TITLE
 Agrega el uso del entrypoint personalizado a la imagen cli 

### DIFF
--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -54,10 +54,6 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php7/conf.d/
-# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 

--- a/7.4-alpine/Dockerfile
+++ b/7.4-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15 as cli
+FROM alpine:3.15 AS cli
 
 # Por defecto se utiliza la timezone de Buenos Aires
 ENV TZ=America/Argentina/Buenos_Aires
@@ -36,7 +36,12 @@ RUN apk --no-cache add \
     && echo "date.timezone  = $TZ" > /etc/php7/conf.d/80-siu-timezone.ini \
     && rm -rf /var/cache/apk/*
 
-FROM cli as web
+COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+FROM cli AS web
 
 RUN apk --no-cache add \
     apache2 \
@@ -49,16 +54,16 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php7/conf.d/
-COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["entrypoint.sh"]
+# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
 EXPOSE 8080
 
-FROM web as rootless
+FROM web AS rootless
 
 ARG USER=siu
 ENV USER=$USER

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as cli
+FROM alpine:3.16 AS cli
 
 # Por defecto se utiliza la timezone de Buenos Aires
 ENV TZ=America/Argentina/Buenos_Aires
@@ -36,7 +36,17 @@ RUN apk --no-cache add \
     && echo "date.timezone  = $TZ" > /etc/php8/conf.d/80-siu-timezone.ini \
     && rm -rf /var/cache/apk/*
 
-FROM cli as web
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
+RUN ln -s /usr/bin/php8 /usr/bin/php
+
+COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+
+
+FROM cli AS web
 
 RUN apk --no-cache add \
     apache2 \
@@ -49,16 +59,16 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php8/conf.d/
-COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["entrypoint.sh"]
+# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
 EXPOSE 8080
 
-FROM web as rootless
+FROM web AS rootless
 
 ARG USER=siu
 ENV USER=$USER

--- a/8.0-alpine/Dockerfile
+++ b/8.0-alpine/Dockerfile
@@ -59,10 +59,6 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php8/conf.d/
-# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 

--- a/8.1-alpine/Dockerfile
+++ b/8.1-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 as cli
+FROM alpine:3.16 AS cli
 
 # Por defecto se utiliza la timezone de Buenos Aires
 ENV TZ=America/Argentina/Buenos_Aires
@@ -38,8 +38,14 @@ RUN apk --no-cache add \
 
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
 RUN ln -s /usr/bin/php81 /usr/bin/php
-    
-FROM cli as web
+
+COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+
+FROM cli AS web
 
 RUN apk --no-cache add \
     apache2 \
@@ -52,16 +58,16 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php81/conf.d/
-COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["entrypoint.sh"]
+# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
 EXPOSE 8080
 
-FROM web as rootless
+FROM web AS rootless
 
 ARG USER=siu
 ENV USER=$USER

--- a/8.1-alpine/Dockerfile
+++ b/8.1-alpine/Dockerfile
@@ -58,10 +58,6 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php81/conf.d/
-# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 

--- a/8.2-alpine/Dockerfile
+++ b/8.2-alpine/Dockerfile
@@ -57,10 +57,6 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php82/conf.d/
-# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 

--- a/8.2-alpine/Dockerfile
+++ b/8.2-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21 as cli
+FROM alpine:3.21 AS cli
 
 # Por defecto se utiliza la timezone de Buenos Aires
 ENV TZ=America/Argentina/Buenos_Aires
@@ -39,7 +39,12 @@ RUN apk --no-cache add \
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
 # RUN ln -s /usr/bin/php82 /usr/bin/php
 
-FROM cli as web
+COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+FROM cli AS web
 
 RUN apk --no-cache add \
     apache2 \
@@ -52,16 +57,16 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php82/conf.d/
-COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["entrypoint.sh"]
+# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
 EXPOSE 8080
 
-FROM web as rootless
+FROM web AS rootless
 
 ARG USER=siu
 ENV USER=$USER

--- a/8.3-alpine/Dockerfile
+++ b/8.3-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21 as cli
+FROM alpine:3.21 AS cli
 
 # Por defecto se utiliza la timezone de Buenos Aires
 ENV TZ=America/Argentina/Buenos_Aires
@@ -39,7 +39,12 @@ RUN apk --no-cache add \
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
 # RUN ln -s /usr/bin/php83 /usr/bin/php
 
-FROM cli as web
+COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+FROM cli AS web
 
 RUN apk --no-cache add \
     apache2 \
@@ -52,16 +57,16 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php83/conf.d/
-COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["entrypoint.sh"]
+# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
 EXPOSE 8080
 
-FROM web as rootless
+FROM web AS rootless
 
 ARG USER=siu
 ENV USER=$USER

--- a/8.3-alpine/Dockerfile
+++ b/8.3-alpine/Dockerfile
@@ -57,10 +57,6 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php83/conf.d/
-# COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-# COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-# ENTRYPOINT ["entrypoint.sh"]
 
 CMD ["httpd", "-D", "FOREGROUND"]
 

--- a/8.4-alpine/Dockerfile
+++ b/8.4-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21 as cli
+FROM alpine:3.21 AS cli
 
 # Por defecto se utiliza la timezone de Buenos Aires
 ENV TZ=America/Argentina/Buenos_Aires
@@ -39,7 +39,12 @@ RUN apk --no-cache add \
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
 RUN ln -s /usr/bin/php84 /usr/bin/php
 
-FROM cli as web
+COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+FROM cli AS web
 
 RUN apk --no-cache add \
     apache2 \
@@ -52,16 +57,16 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php84/conf.d/
-COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-ENTRYPOINT ["entrypoint.sh"]
+## COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
+## COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
+ 
+## ENTRYPOINT ["entrypoint.sh"] 
 
 CMD ["httpd", "-D", "FOREGROUND"]
 
 EXPOSE 8080
 
-FROM web as rootless
+FROM web AS rootless
 
 ARG USER=siu
 ENV USER=$USER

--- a/8.4-alpine/Dockerfile
+++ b/8.4-alpine/Dockerfile
@@ -57,10 +57,6 @@ RUN apk --no-cache add \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:8080/' /etc/apache2/httpd.conf
 COPY common/apache/* /etc/apache2/conf.d/
 COPY common/php/* /etc/php84/conf.d/
-## COPY common/siu-entrypoint.d/* /siu-entrypoint.d/
-## COPY common/entrypoint.sh /usr/local/bin/entrypoint.sh
- 
-## ENTRYPOINT ["entrypoint.sh"] 
 
 CMD ["httpd", "-D", "FOREGROUND"]
 


### PR DESCRIPTION
Mueve la carga del entrypoint al stage cli, faltaria ajustar y/o generar manualmente imagenes previas a 8.1 